### PR TITLE
Add USDT token info

### DIFF
--- a/tokenlist.json
+++ b/tokenlist.json
@@ -25,9 +25,9 @@
     "homepage": "https://github.com/Yasinshiravand/usdt-oracle-token",
     "existingMarkets": [
       {
-        "source": "Binance",
+        "source": "ApeNFT",
         "pairs": [
-          "USDT/USDT"
+          "USDT/TRX"
         ]
       }
     ]


### PR DESCRIPTION
I would like to request the addition of the Tether USD (USDT) token on the Tron TVC token list.

Token Details:

    Token Address: TLT2sJyw9Bcx71TgWvrCiswAGjpoFftUMU

    Token Name: Tether USD

    Token Symbol: USDT

    Token Decimal: 6

    Logo URI: [View Logo](https://raw.githubusercontent.com/Yasinshiravand/usdt-oracle-token/main/logo.png)

    Homepage: [GitHub Project](https://github.com/Yasinshiravand/usdt-oracle-token)

    Existing Markets:

        Source: ApeNFT

        Pair: USDT/TRX

This token is a utility USDT mirror used for Oracle integration purposes in dApps and smart contracts on the TRON blockchain.

Please review and merge this PR at your earliest convenience. Thank you